### PR TITLE
Restrict binary-strict to version 0.4.8.2

### DIFF
--- a/webify.cabal
+++ b/webify.cabal
@@ -30,7 +30,7 @@ executable webify
                        bytestring >= 0.9,
                        blaze-builder >= 0.3.3.4,
                        binary >= 0.5.1,
-                       binary-strict >= 0.4.8.2,
+                       binary-strict == 0.4.8.2,
                        text >= 0.7.2,
                        filepath >= 1.3.0,
                        zlib >= 0.5.4,


### PR DESCRIPTION
With version `0.4.8.3` was not being able to install webify
- [x] Lock `binary-strict` dependency to `0.4.8.2`.
