### PR TITLE
Bump optparse-applicative to <0.16

### DIFF
--- a/webify.cabal
+++ b/webify.cabal
@@ -36,7 +36,7 @@ executable webify
                        filepath >= 1.3.0,
                        zlib >= 0.5.4,
                        xmlgen >= 0.6.2.1,
-                       optparse-applicative >= 0.10.0 && <0.15,
+                       optparse-applicative >= 0.10.0 && <0.16,
                        vector >= 0.10.0,
                        hopfli >= 0.1.0.0 && < 0.3
 


### PR DESCRIPTION
Current [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative) is on 0.15.1 on hackage, so the version bounds need to be bumped.